### PR TITLE
Throw an exception if the input stream fails to get the object

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -78,6 +78,10 @@ public class S3AInputStream extends FSInputStream {
     wrappedObject = client.getObject(request);
     wrappedStream = wrappedObject.getObjectContent();
 
+    if (wrappedObject == null) {
+      throw new IOException("Failed to make S3 GetObject request");
+    }
+
     if (wrappedStream == null) {
       throw new IOException("Null IO stream");
     }


### PR DESCRIPTION
If the `GetObjectRequest` fails for whatever reason, we'll get a `NullPointerException` when trying to use the input stream.
