### PR TITLE
Ensure the file is open before trying to seek

### DIFF
--- a/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
+++ b/src/main/java/org/apache/hadoop/fs/s3a/S3AInputStream.java
@@ -92,6 +92,12 @@ public class S3AInputStream extends FSInputStream {
 
   @Override
   public synchronized void seek(long pos) throws IOException {
+    if (closed) {
+      throw new IOException("Stream closed");
+    }
+
+    openIfNeeded();
+
     if (this.pos == pos) {
       return;
     }


### PR DESCRIPTION
If the user tries to seek() before read()ing the input stream, wrappedObject is going to be null, and cause a NullPointerException to be thrown.
